### PR TITLE
Update link to `iproj.json` metadata docs

### DIFF
--- a/docs/pages/developing/local/structure.md
+++ b/docs/pages/developing/local/structure.md
@@ -40,7 +40,7 @@ While it is possible to use `INCDIR` and then not provide a directory on the inc
 If you want your local project to resolve files on the IFS, make sure you specify your 'include directories' 
 
 * by using the `INCDIR` parameter available on most ILE compilers,
-* or inside the [`iproj.json` file with the `includePath` property](https://ibm.github.io/ibmi-bob/#/prepare-the-project/iproj-json?id=includepath) to the paths where the compiler should look up (this is supported by ibmi-bob)
+* or inside the [`iproj.json` file with the `includePath` property](https://ibm.github.io/vscode-ibmi-projectexplorer/#/pages/ibm-i-projects/iproj-json?id=includepath) to the paths where the compiler should look up (this is supported by ibmi-bob)
 
 ## Example project structure
 


### PR DESCRIPTION
The `ibmi-bob` docs will eventually be removing the project metadata documentation for `iproj.json` in favor of having this information in the Project Explorer docs [here](https://ibm.github.io/vscode-ibmi-projectexplorer/#/pages/ibm-i-projects/overview).

This PR updates one of the `ibmi-bob` links.