### PR TITLE
Included new DirectivesCase linter option

### DIFF
--- a/docs/pages/developing/local/actions.md
+++ b/docs/pages/developing/local/actions.md
@@ -25,6 +25,7 @@ These variables can be used for local development. They can be referenced in `ac
 | `&LOCALPATH`    | The full path to the file on the local machine                                    |
 | `&FULLPATH`     | The full path to the file on the remote machine                                   |
 | `&WORKDIR`      | The working directory. Typically this means the deploy directory                  |
+| `&FILEDIR`      | The directory of the file on the remote machine                                   | 
 | `&PARENT`       | The local parent directory                                                        |
 | `&BASENAME`     | The basename of the file (`name.ext`). Can also use `{filename}`                  |
 | `&NAME`         | The name of the file (or use `&NAMEL` for lowercase)                              |

--- a/docs/pages/extensions/rpgle/linter.md
+++ b/docs/pages/extensions/rpgle/linter.md
@@ -47,7 +47,8 @@ Below are some available lint configs. [See the `rpglint.json` schema for the mo
 | 🌟 | StringLiteralDupe | boolean | Duplicate string literals are not allowed. |
 | 🌟 | RequireBlankSpecial | boolean | *BLANK must be used over empty string literals. |
 | 🌟 | CopybookDirective | string | Force which directive which must be used to include other source. (`COPY` or `INCLUDE`) |
-| 🌟 | UppercaseDirectives | boolean | Directives must be in uppercase. |
+| 🌟 | DirectivesCase | string | Directives must be in the specified case. (`lower` or `upper`) |
+| 🌟 | UppercaseDirectives | boolean | **Deprecated** use `DirectivesCase` instead. Directives must be in uppercase. |
 | 🤔 | NoSQLJoins | boolean | JOINs in Embedded SQL are not allowed. |
 | 🌟 | NoGlobalsInProcedures | boolean | Globals are not allowed in procedures. |
 | 🌟 | SpecificCasing | array | Specific casing for op codes, declartions or built-in functions codes. |
@@ -84,7 +85,7 @@ If you want all `DCL` to be lower case and all `BIF`s to be upper case, then it 
    ]
 ```
 
-If you wanted `%parms` and `%timestamp` to always be lower case, amd all other BIFs to be upper case, then it would be coded like this:
+If you wanted `%parms` and `%timestamp` to always be lower case, and all other BIFs to be upper case, then it would be coded like this:
 
 ```json
    "SpecificCasing": [


### PR DESCRIPTION
Added the new `DirectivesCase` linter option to the appropriate page and also added a note that the `UppercaseDirectives` option has been deprecated.