### PR TITLE
Add PTF ID's for Debug Service v2

### DIFF
--- a/src/content/docs/developing/debug/index.mdx
+++ b/src/content/docs/developing/debug/index.mdx
@@ -80,9 +80,12 @@ To make use of the Debug Service, you need the following PTFs:
    * `/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit`
 
 </TabItem>
-<TabItem label="Version 2">
+<TabItem label="Version 2" >
 
-* *Version 2 not yet released.*
+* Host debugger in 5770SS1:
+   * IBM i 7.5 PTF SI86229
+   * IBM i 7.4 PTF SI86178
+   * IBM i 7.3 PTF SI85976
 * Java 11 is required
    * `/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`
 


### PR DESCRIPTION
This PR adds the PTF ID's for Debug Service v2, as specified by the [IBM i Debug](https://open-vsx.org/extension/IBM/ibmidebug) extension.