### PR TITLE
Describe requirement for 5770WDS option 60 for Debug Service v2

### DIFF
--- a/src/content/docs/developing/debug/index.mdx
+++ b/src/content/docs/developing/debug/index.mdx
@@ -88,6 +88,8 @@ To make use of the Debug Service, you need the following PTFs:
    * IBM i 7.3 PTF SI85976
 * Java 11 is required
    * `/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`
+* 5770WDS option 60 is required
+   * Workstation Tools - Base
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
This PR adds the requirement of 5770WDS option 60 (Workstation Tools - Base) for Debug Service v2, not (yet) documented in the [IBM i Debug](https://open-vsx.org/extension/IBM/ibmidebug) extension.