### PR TITLE
Added more required PTFs for Debug v2

### DIFF
--- a/src/content/docs/developing/debug/index.mdx
+++ b/src/content/docs/developing/debug/index.mdx
@@ -83,9 +83,9 @@ To make use of the Debug Service, you need the following PTFs:
 <TabItem label="Version 2" >
 
 * Host debugger in 5770SS1:
-   * IBM i 7.5 PTF SI86229
-   * IBM i 7.4 PTF SI86178
-   * IBM i 7.3 PTF SI85976
+   * IBM i 7.5 PTF SI86229 and SI82343
+   * IBM i 7.4 PTF SI86178 and SI82335
+   * IBM i 7.3 PTF SI85976 and SI82198
 * Java 11 is required
    * `/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`
 * 5770WDS option 60 is required


### PR DESCRIPTION
Add more PTFs that are required for the Debug Service v2 to run correctly.
This is based on requirements from the debugger in RDi 9.8 and it was confirmed as being required here: https://github.com/orgs/codefori/discussions/420#discussioncomment-10386999