### PR TITLE
Added minimum OS version requirtement

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -13,6 +13,7 @@ Maintain and compile your RPGLE, CL, COBOL, C/CPP on the IBM i right from Visual
 
 ## Requirements
 
+- IBM i 7.3 TR 5 minimum
 - SSH Daemon must be started on IBM i.
    - (Licensed program 5733-SC1 provides SSH support.)
    - `STRTCPSVR *SSHD` starts the daemon.


### PR DESCRIPTION
Adds IBM i os `7.3 TR 5` as the minimum required version to run Code for IBM i without issues.
See https://github.com/codefori/vscode-ibmi/issues/2017#issuecomment-2369143236