### PR TITLE
Fix build error and reorder IBM i versions

### DIFF
--- a/src/content/docs/developing/debug/index.mdx
+++ b/src/content/docs/developing/debug/index.mdx
@@ -73,9 +73,9 @@ To make use of the Debug Service, you need the following PTFs:
 <TabItem label="Version 2.0.2 >
 
 * IBM i debug client v2.0.2 requires the following host PTFs:
-   * 7.3 PTF SJ02996
-   * 7.4 PTF SJ03026
    * 7.5 PTF SJ03030
+   * 7.4 PTF SJ03026
+   * 7.3 PTF SJ02996
 * Java 11 is required via LPP 5770JV1 Option 19 (not Java from Yum)
    * `/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`
    * [IBM documentation for PTFs](https://www.ibm.com/support/pages/download-installation-and-usage-java-11-ibm-i-os)   

--- a/src/content/docs/developing/debug/index.mdx
+++ b/src/content/docs/developing/debug/index.mdx
@@ -70,7 +70,7 @@ To debug a program from the Object Browser, right-click on the program object an
 To make use of the Debug Service, you need the following PTFs:
 
 <Tabs>
-<TabItem label="Version 2.0.2 >
+<TabItem label="Version 2.0.2" >
 
 * IBM i debug client v2.0.2 requires the following host PTFs:
    * 7.5 PTF SJ03030


### PR DESCRIPTION
This PR will

- fix the build error caused by a tag error
- reorder the IBM i versions for the debugger v2.0.2 to the same order as the other versions (newest first)