### PR TITLE
Overtype now in VS Code 1.96+

### DIFF
--- a/src/content/docs/tips/tricks.mdx
+++ b/src/content/docs/tips/tricks.mdx
@@ -46,7 +46,7 @@ Right click and click 'Search' on IFS directories and source files to search thr
 
 ### Overtype
 
-VS Code works in "insert" mode. This can be annoying when editing a fixed mode source, for example DDS. Fortunately there is an [Overtype extension](https://marketplace.visualstudio.com/items?itemName=DrMerfy.overtype)<Icon name="external" color="cyan" class="icon-inline" /> that allows you to toggle between insert and  overtype, and can also display the current mode in the status bar.
+Prior to release 1.96, VS Code worked only in "insert" mode. If you cannot upgrade, then may install the  [Overtype extension](https://marketplace.visualstudio.com/items?itemName=DrMerfy.overtype)<Icon name="external" color="cyan" class="icon-inline" /> which allows you to toggle between insert and  overtype.
 
 ### Font Size
 


### PR DESCRIPTION
Clarify that extension is not longer needed since VS Code 1.96.