### PR TITLE
Update linter.mdx fixed a typo on %Timestamp

### DIFF
--- a/src/content/docs/extensions/rpgle/linter.mdx
+++ b/src/content/docs/extensions/rpgle/linter.mdx
@@ -123,7 +123,7 @@ Or, if for some reason, you wanted `%timestamp` to always be coded as `%TimeStam
       },
       {
          "operation": "%timestamp",
-         "expected": "*TimeStamp"
+         "expected": "%TimeStamp"
       },
       {
          "operation": "*bif",


### PR DESCRIPTION
Changed *TimesStamp to %TimeStamp