### PR TITLE
Set minimum OS version to 7.3 TR8

### DIFF
--- a/src/content/docs/install.mdx
+++ b/src/content/docs/install.mdx
@@ -8,7 +8,7 @@ import { CardGrid, Card, Badge, LinkCard, Icon } from '@astrojs/starlight/compon
 
 ## Requirements
 
-- IBM i 7.3 TR 5 minimum
+- IBM i 7.3 TR 8 minimum
 - SSH Daemon must be started on IBM i.
    - (Licensed program 5733-SC1 provides SSH support.)
    - `STRTCPSVR *SSHD` starts the daemon.


### PR DESCRIPTION
Since we now use the `LIBRARY_INFO` SQL service, the minimum OS version needs to be 7.3 TR 8.