### PR TITLE
slight adjustment to wording in the db2 for i section

### DIFF
--- a/src/content/docs/extensions/db2i/index.mdx
+++ b/src/content/docs/extensions/db2i/index.mdx
@@ -41,7 +41,7 @@ SQL statements are executed using the active job selected in the SQL Job Manager
 
 ### SQL prefixes
 
-Newer version of SQL provided by Db2 for i allows you to run CL commands in a script. There are also `json`, `csv`, `sql` and `rpg` prefixes, which will open the result set in the chosen format.
+SQL provided by Db2 for i allows you to run CL commands in a script. Additionally there are `json`, `csv`, `sql` and `rpg` prefixes, which will open the result set in the chosen format.
 
 ```sql
 -- result set as normal table


### PR DESCRIPTION
The current version of the SQL prefixes (FKA processors) section felt a bit cumbersome to read. Submitting potential change. Perhaps we could say _Db2 for i extension_ or _this extension_? 