### PR TITLE
Change order of AI links to same of extensons above

### DIFF
--- a/src/content/docs/extensions/db2i/AI/code-assistant.mdx
+++ b/src/content/docs/extensions/db2i/AI/code-assistant.mdx
@@ -17,8 +17,8 @@ import { Image } from 'astro:assets';
   </Card>
 </CardGrid>
 <CardGrid>
-  <LinkCard title="GitHub Copilot" href="https://marketplace.visualstudio.com/items?itemName=GitHub.copilot" icon="github"/>
   <LinkCard title="Continue" href="https://marketplace.visualstudio.com/items?itemName=Continue.continue" icon="github"/>
+  <LinkCard title="GitHub Copilot" href="https://marketplace.visualstudio.com/items?itemName=GitHub.copilot" icon="github"/>
 </CardGrid>
 
 ## Introduction


### PR DESCRIPTION
The links for the AI extensions were in the wrong order - this is fixed in this PR.