### PR TITLE
Update restart ADMIN1 server requirement

### DIFF
--- a/src/content/docs/developing/debug/configure.mdx
+++ b/src/content/docs/developing/debug/configure.mdx
@@ -37,6 +37,8 @@ To make use of the Debug Service, you need the following PTFs:
 
 **All OS versions require** 5770WDS option 60 (Workstation Tools - Base).
 
+<Aside type="note">You need to restart the ADMIN1 server after applying a Navigator PTF. </Aside>
+
 </TabItem>
 
 <TabItem label="Version 3" >
@@ -136,7 +138,7 @@ Below are the base requirements to configure the certificate:
 
 ## Updating the service
 
-When there are newer Debug service or Navigator/HTTP Group PTFs, the following steps might be required:
+When there are newer Debug service or Navigator/HTTP Group PTFs, the following steps are required:
 1. Restart ADMIN1 server
    - If HTTP Group PTF does not show as applied, IPL might be required.
 2. Regenerate debug service trust store (as described above)


### PR DESCRIPTION
Update from user feedback:
1. Restart ADMIN1 server is required when there is a new Navigator PTF.
2. Add a note for restarting ADMIN1 server under the "Version 3.0.1" tab. This step is a must for the 3.0.1 update.